### PR TITLE
chore: Begin migration to Bevy for AAA engine overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "yum-osu"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-macroquad = "0.4.13"
+bevy = { version = "0.14", features = ["dynamic_linking"] }
+bevy_kira_audio = "0.20"
 rand = "0.8.5"
-rhythms = "0.1.0"
-rodio = "0.19.0"
+rayon = "1.10.0"
 aubio = "0.2.1"
 biquad = "0.4.2"
-rayon = "1.10.0"
+
+[profile.dev]
+opt-level = 1
+[profile.dev.package."*"]
+opt-level = 3


### PR DESCRIPTION
## Migrate from Macroquad to Bevy Engine (Issue #1)

This PR begins the migration of yum-osu from Macroquad to the Bevy game engine for AAA scalability and modularity. It includes:
- Replacement of Macroquad dependencies with Bevy and Bevy Kira Audio in `Cargo.toml`
- Lays the groundwork for future Bevy plugin and ECS architecture

**Next Steps:**
- Port window setup, main loop, and basic rendering logic to Bevy ECS
- Remove previous Macroquad references from Rust code
- Refactor game state to Bevy's `States` system
- Migrate input, rendering, and audio code to Bevy-compatible modules

This addresses [Issue #1: Migrate from Macroquad to Bevy Game Engine](https://github.com/CodingInCarhartts/yum-osu/issues/1).